### PR TITLE
fix: add missing /workspace argument to Docker scan commands

### DIFF
--- a/examples/test-dotnet-solution.sh
+++ b/examples/test-dotnet-solution.sh
@@ -57,7 +57,7 @@ docker run --rm \
     -v "$(pwd)/$PROJECT_DIR:/workspace:ro" \
     -v "$(pwd)/output/eshopweb:/output" \
     ghcr.io/emilholmegaard/doc-architect:latest \
-    scan --config /workspace/docarchitect.yaml --output /output
+    scan /workspace --config /workspace/docarchitect.yaml --output /output
 
 echo ""
 echo "✓ eShopOnWeb scan complete."

--- a/examples/test-python-fastapi.sh
+++ b/examples/test-python-fastapi.sh
@@ -56,7 +56,7 @@ docker run --rm \
     -v "$(pwd)/$PROJECT_DIR:/workspace:ro" \
     -v "$(pwd)/output/fastapi:/output" \
     ghcr.io/emilholmegaard/doc-architect:latest \
-    scan --config /workspace/docarchitect.yaml --output /output
+    scan /workspace --config /workspace/docarchitect.yaml --output /output
 
 echo ""
 echo "✓ FastAPI scan complete."

--- a/examples/test-spring-microservices.sh
+++ b/examples/test-spring-microservices.sh
@@ -57,7 +57,7 @@ docker run --rm \
     -v "$(pwd)/$PROJECT_DIR:/workspace:ro" \
     -v "$(pwd)/output/piggymetrics:/output" \
     ghcr.io/emilholmegaard/doc-architect:latest \
-    scan --config /workspace/docarchitect.yaml --output /output
+    scan /workspace --config /workspace/docarchitect.yaml --output /output
 
 echo ""
 echo "✓ PiggyMetrics scan complete."


### PR DESCRIPTION
## Problem

The real-world test scripts were generating empty output files because the Docker scan commands were missing the workspace path as the first positional parameter.

**Symptoms:**
- `api-catalog.md` was 53 bytes with "No API endpoints found"
- `dependency-graph.md` was 67 bytes (mostly empty)
- `index.md` showed all metrics at 0 (Components: 0, Dependencies: 0, etc.)

**Root Cause:**
The `scan` command without a positional parameter defaults to `.` (current working directory). Inside the Docker container, this is NOT the mounted `/workspace` directory where project files are located.

```bash
# Before (broken)
docker run --rm     -v "$(pwd)/$PROJECT_DIR:/workspace:ro"     -v "$(pwd)/output/piggymetrics:/output"     ghcr.io/emilholmegaard/doc-architect:latest     scan --config /workspace/docarchitect.yaml --output /output
    # Missing workspace path! Defaults to container's CWD
```

## Solution

Added `/workspace` as the first positional parameter to all Docker scan commands:

```bash
# After (fixed)
scan /workspace --config /workspace/docarchitect.yaml --output /output
     ^^^^^^^^^
```

## Changes

- ✅ `examples/test-spring-microservices.sh` - Added `/workspace` argument
- ✅ `examples/test-dotnet-solution.sh` - Added `/workspace` argument  
- ✅ `examples/test-python-fastapi.sh` - Added `/workspace` argument

## Testing

Tested `test-spring-microservices.sh` against PiggyMetrics:

**Before Fix:**
- Components: 0
- Dependencies: 0
- API Endpoints: 0
- File sizes: 53-148 bytes (nearly empty)

**After Fix:**
- Components: 9 ✅
- Dependencies: 24 ✅
- API Endpoints: 11 ✅
- File sizes: 3-4KB (actual content)

**Sample Output:**
```
Architecture Model Summary:
  Components:     9
  Dependencies:   24
  API Endpoints:  11
  Data Entities:  0
  Message Flows:  0
  Relationships:  0
```

**Generated Files:**
- `api-catalog.md`: 4.0K (was 53B) - Contains actual endpoint documentation
- `dependency-graph.md`: 3.1K (was 67B) - Contains Maven dependencies
- `c4-component.md`: 3.4K (was 56B) - Contains component diagrams

## Impact

This fix ensures that:
1. Real-world test scripts work correctly when run locally
2. GitHub Actions CI workflow will properly validate against OSS projects
3. Documentation examples show realistic output
4. Weekly scheduled tests will catch regressions

Fixes the mismatch between console output and generated files reported in issue discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)