### PR TITLE
fix: use GitHub CLI API for artifact download (fixes action restriction)

### DIFF
--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -39,26 +39,51 @@ jobs:
 
       - name: Download latest Sokrates reports
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          workflow: sokrates-analysis.yml
-          name: sokrates-reports
-          path: ./site/sokrates
-          if_no_artifact_found: warn
-          search_artifacts: true
-        continue-on-error: true
-
-      - name: Verify Sokrates integration
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ -d "./site/sokrates" ]; then
-            echo "✅ Sokrates reports successfully integrated into TechDocs"
-            echo "Contents of sokrates directory:"
-            ls -la ./site/sokrates/
-          else
-            echo "⚠️  No Sokrates reports found - site will deploy without them"
+          echo "🔍 Searching for latest Sokrates reports artifact..."
+
+          # Find the latest successful Sokrates workflow run
+          RUN_ID=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/actions/workflows/sokrates-analysis.yml/runs?status=success&per_page=1" \
+            --jq '.workflow_runs[0].id')
+
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "⚠️  No successful Sokrates workflow runs found yet"
             echo "This is normal if Sokrates analysis hasn't run yet"
+            exit 0
           fi
+
+          echo "📦 Found workflow run: $RUN_ID"
+
+          # Download the artifact
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/actions/runs/$RUN_ID/artifacts" \
+            --jq '.artifacts[] | select(.name=="sokrates-reports") | .id' | head -1 | while read ARTIFACT_ID; do
+
+            if [ -n "$ARTIFACT_ID" ]; then
+              echo "📥 Downloading artifact: $ARTIFACT_ID"
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "/repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > sokrates-reports.zip
+
+              # Extract to site directory
+              mkdir -p ./site/sokrates
+              unzip -q sokrates-reports.zip -d ./site/sokrates
+              echo "✅ Sokrates reports successfully integrated into TechDocs"
+              echo "Contents of sokrates directory:"
+              ls -la ./site/sokrates/
+            else
+              echo "⚠️  No sokrates-reports artifact found in workflow run"
+            fi
+          done
+        continue-on-error: true
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions error from #116 where `dawidd6/action-download-artifact@v6` is blocked by repository restrictions that only allow GitHub-official or emilholmegaard-owned actions.

## Problem

After merging #116, the TechDocs workflow fails with:
```
Error: The action dawidd6/action-download-artifact@v6 is not allowed in emilholmegaard/doc-architect 
because all actions must be from a repository owned by emilholmegaard, created by GitHub, or verified 
in the GitHub Marketplace.
```

## Solution

Replace the third-party action with GitHub's official CLI (`gh`), which is pre-installed in all GitHub Actions runners.

### Implementation

The new approach uses GitHub REST API via the `gh` CLI:

1. **Query for latest successful Sokrates workflow run**
   ```bash
   gh api /repos/{repo}/actions/workflows/sokrates-analysis.yml/runs?status=success&per_page=1
   ```

2. **Extract artifact ID from the run**
   ```bash
   gh api /repos/{repo}/actions/runs/{run_id}/artifacts
   ```

3. **Download artifact as ZIP**
   ```bash
   gh api /repos/{repo}/actions/artifacts/{artifact_id}/zip > sokrates-reports.zip
   ```

4. **Extract to site directory**
   ```bash
   unzip -q sokrates-reports.zip -d ./site/sokrates
   ```

### Advantages

✅ Uses only GitHub-official tools (gh CLI)  
✅ No third-party dependencies  
✅ Same graceful error handling (`continue-on-error: true`)  
✅ Comprehensive logging for debugging  
✅ No changes to Sokrates workflow needed  

## Testing

- [x] Workflow YAML syntax validated
- [x] Logic tested with GitHub API endpoints
- [x] Error handling verified (missing artifacts, no runs)

This will be fully validated when:
1. TechDocs workflow runs on main after merge
2. Sokrates reports are downloaded successfully
3. Unified site deploys without errors

## Related

- Follow-up to #116 (Sokrates integration)
- Resolves action restriction error from #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>