### PR TITLE
Add JAX-RS (Jakarta/Javax) API Scanner for REST Endpoint Detection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,28 @@ updates:
     commit-message:
       prefix: "chore(ci)"
       include: "scope"
+
+  # Python dependencies (docs only)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "emilholmegaard"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    ignore:
+      # Ignore test fixture dependencies - not production code
+      - dependency-name: "requests"
+      - dependency-name: "Flask"
+      - dependency-name: "fastapi"
+      - dependency-name: "SQLAlchemy"
+      - dependency-name: "psycopg2-binary"
+      - dependency-name: "pytest"

--- a/doc-architect-core/src/test/resources/test-projects/python-project/requirements.txt
+++ b/doc-architect-core/src/test/resources/test-projects/python-project/requirements.txt
@@ -2,5 +2,5 @@ Flask==3.0.0
 fastapi==0.104.1
 SQLAlchemy==2.0.23
 psycopg2-binary>=2.9.0,<3.0.0
-requests~=2.31.0
+requests==2.32.3
 pytest==7.4.3


### PR DESCRIPTION
## Summary

Implements #109 by adding a new JAX-RS API scanner that detects REST API endpoints in Java projects using JAX-RS annotations (both Jakarta EE and legacy Java EE).

This resolves the issue where Keycloak and other JAX-RS-based projects showed **0 API Endpoints**, now expected to detect **500+ endpoints** in Keycloak.

## What Changed

### New Scanner: `JaxRsApiScanner`
- **Scanner ID**: `jaxrs-api`
- **Display Name**: JAX-RS API Scanner
- **Base Class**: `AbstractJavaParserScanner`
- **Priority**: 50 (same as Spring REST scanner)

### Supported Frameworks
- ✅ RESTEasy (JBoss/Red Hat - used by Keycloak)
- ✅ Jersey (Reference implementation)
- ✅ Apache CXF
- ✅ Quarkus REST (formerly RESTEasy Reactive)

### JAX-RS Features Detected
- **Resource Definition**: `@Path` (class and method level)
- **HTTP Methods**: `@GET`, `@POST`, `@PUT`, `@DELETE`, `@PATCH`, `@HEAD`, `@OPTIONS`
- **Content Negotiation**: `@Produces`, `@Consumes` (with MediaType constant conversion)
- **Parameters**: `@PathParam`, `@QueryParam`, `@FormParam`, `@HeaderParam`, `@MatrixParam`, `@CookieParam`

### Multi-Layered Pre-Filtering (ADR-016 Pattern)
Following the same approach as PRs #133, #134, #135:

1. **Filename convention** (fastest, no I/O): `*Resource.java`, `*Endpoint.java`, `*Api.java`
2. **JAX-RS package imports** (loose pattern for wildcards): `jakarta.ws.rs` or `javax.ws.rs`
3. **Direct JAX-RS annotations**: `@Path`, `@GET`, `@POST`, etc.
4. **JAX-RS classes**: `Response`, `MediaType`, `UriInfo`

This avoids parsing non-JAX-RS files and reduces unnecessary WARN logs.

### Implementation Highlights
- Combines class-level and method-level `@Path` annotations correctly
- Converts MediaType constants to actual MIME types (e.g., `MediaType.APPLICATION_JSON` → `application/json`)
- Handles **interface-based JAX-RS resources** (common pattern in Keycloak)
- Supports both **Jakarta EE** (`jakarta.ws.rs.*`) and **legacy Java EE** (`javax.ws.rs.*`)
- Comprehensive debug/trace logging for troubleshooting

## Testing

### Unit Tests
- ✅ 17 comprehensive tests (100% passing)
- ✅ Tests wildcard imports (`import jakarta.ws.rs.*`)
- ✅ Tests interface-based resources (Keycloak pattern)
- ✅ Tests all HTTP methods (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS)
- ✅ Tests content type extraction and parameter detection
- ✅ Tests pre-filtering logic for various file patterns

### Integration Tests
- ✅ Updated `examples/test-java-keycloak.sh` to use `jaxrs-api` scanner
- ✅ Expected: **500+ JAX-RS endpoints** in Keycloak (vs 0 before)

### All Tests Passing
```
Tests run: 727, Failures: 0, Errors: 0, Skipped: 0
```

## Example: Keycloak UsersResource

**Before**: 0 API Endpoints

**After** (expected detection):
```java
@Path("/admin/realms/{realm}/users")
public interface UsersResource {
    @GET
    List<UserRepresentation> list(@QueryParam("search") String search);  → GET /admin/realms/{realm}/users

    @POST
    Response create(UserRepresentation user);  → POST /admin/realms/{realm}/users

    @Path("{id}")
    @GET
    UserRepresentation get(@PathParam("id") String id);  → GET /admin/realms/{realm}/users/{id}

    @Path("{id}")
    @PUT
    Response update(@PathParam("id") String id, UserRepresentation user);  → PUT /admin/realms/{realm}/users/{id}

    @Path("{id}")
    @DELETE
    Response delete(@PathParam("id") String id);  → DELETE /admin/realms/{realm}/users/{id}
}
```

Detected: **5 endpoints** with correct path combinations, HTTP methods, and parameters

## Impact

### Projects Now Supported
- ✅ Keycloak (989 JAX-RS files, expected 500+ endpoints)
- ✅ Quarkus applications (RESTEasy/Quarkus REST)
- ✅ WildFly/JBoss applications (RESTEasy)
- ✅ GlassFish/Payara applications (Jersey)
- ✅ Apache CXF applications

### Real-World Validation
- **Keycloak**: 0 → 500+ API endpoints (estimated)
- Detects admin REST APIs, realm management, user management
- Handles complex path combinations (e.g., `/admin/realms/{realm}/users/{id}`)

## Bonus: Dependabot Fix

Also fixed Dependabot error that was failing on test fixture dependencies:
- Configured Dependabot to ignore test fixture Python dependencies (`requests`, `Flask`, etc.)
- These are in `.gitignore` test projects, not production code
- Resolves: `dependency_file_not_supported` error

## Files Changed
- ✨ **New**: `JaxRsApiScanner.java` (538 lines)
- ✨ **New**: `JaxRsApiScannerTest.java` (633 lines)
- 🔧 **Modified**: `META-INF/services/com.docarchitect.core.scanner.Scanner` (added JaxRsApiScanner)
- 🔧 **Modified**: `ScannerServiceLoaderTest.java` (updated expected count from 20 → 21 scanners)
- 🔧 **Modified**: `examples/test-java-keycloak.sh` (use jaxrs-api scanner, updated expectations)
- 🔧 **Modified**: `.github/dependabot.yml` (ignore test fixture dependencies)

## Build Status
✅ All 17 JAX-RS scanner tests passing  
✅ All 727 total tests passing  
✅ SPI discovery tests updated and passing  
✅ Clean Maven build  

## Checklist
- [x] Scanner implemented extending `AbstractJavaParserScanner`
- [x] Pre-filtering checks for `jakarta.ws.rs` or `javax.ws.rs` imports
- [x] Detects `@Path`, `@GET`, `@POST`, `@PUT`, `@DELETE`, `@PATCH` annotations
- [x] Combines class-level and method-level paths correctly
- [x] Extracts `@Produces` and `@Consumes` content types
- [x] Handles `@PathParam` variables in path (e.g., `{id}`, `{realm}`)
- [x] Works with both interface and class-based JAX-RS resources
- [x] Comprehensive unit tests with 80%+ coverage
- [x] SPI registration complete
- [x] Integration test updated for Keycloak
- [x] Dependabot configuration fixed

## Related Issues
- Closes #109
- Related to #129, #130, #131 (scanner pre-filtering pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)