### PR TITLE
feat: implement Sidekiq job scanner for Ruby message flows (Issue #164)

### DIFF
--- a/doc-architect-core/src/main/java/com/docarchitect/core/scanner/impl/ruby/SidekiqScanner.java
+++ b/doc-architect-core/src/main/java/com/docarchitect/core/scanner/impl/ruby/SidekiqScanner.java
@@ -1,0 +1,354 @@
+package com.docarchitect.core.scanner.impl.ruby;
+
+import com.docarchitect.core.model.MessageFlow;
+import com.docarchitect.core.scanner.ScanContext;
+import com.docarchitect.core.scanner.ScanResult;
+import com.docarchitect.core.scanner.base.AbstractRegexScanner;
+import com.docarchitect.core.util.Technologies;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Scanner for Sidekiq worker definitions and job invocations in Ruby source files.
+ *
+ * <p>Sidekiq is a background job processing system for Ruby. This scanner detects:
+ * <ul>
+ *   <li>Worker definitions using {@code include Sidekiq::Worker}</li>
+ *   <li>Job invocations using {@code .perform_async()}, {@code .perform_in()}, {@code .perform_at()} methods</li>
+ *   <li>Queue names from {@code sidekiq_options} configurations</li>
+ * </ul>
+ *
+ * <p><b>Supported Patterns</b></p>
+ * <ul>
+ *   <li>{@code include Sidekiq::Worker} - Worker definition</li>
+ *   <li>{@code include ApplicationWorker} - Rails application worker (wraps Sidekiq::Worker)</li>
+ *   <li>{@code sidekiq_options queue: :notifications} - Queue specification with symbol</li>
+ *   <li>{@code sidekiq_options queue: 'emails'} - Queue specification with string</li>
+ *   <li>{@code EmailWorker.perform_async(args)} - Asynchronous job invocation</li>
+ *   <li>{@code EmailWorker.perform_in(1.hour, args)} - Delayed job invocation</li>
+ *   <li>{@code EmailWorker.perform_at(time, args)} - Scheduled job invocation</li>
+ * </ul>
+ *
+ * <p><b>Queue Name Extraction</b></p>
+ * <ul>
+ *   <li>From sidekiq_options: {@code sidekiq_options queue: :notifications}</li>
+ *   <li>Default queue: "default" (Sidekiq's default)</li>
+ * </ul>
+ *
+ * <p><b>Message Flow Model</b></p>
+ * <ul>
+ *   <li>Producer: Component that calls .perform_async(), .perform_in(), or .perform_at()</li>
+ *   <li>Consumer: Component that includes Sidekiq::Worker or ApplicationWorker</li>
+ *   <li>Topic/Queue: Sidekiq queue name</li>
+ *   <li>Type: "sidekiq"</li>
+ * </ul>
+ *
+ * <p><b>Regex Patterns</b></p>
+ * <ul>
+ *   <li>{@code WORKER_INCLUDE_PATTERN}: {@code include\s+(?:Sidekiq::Worker|ApplicationWorker)}</li>
+ *   <li>{@code CLASS_DEFINITION_PATTERN}: {@code class\s+([A-Z][a-zA-Z0-9_]*(?:::[A-Z][a-zA-Z0-9_]*)*)}</li>
+ *   <li>{@code SIDEKIQ_OPTIONS_PATTERN}: {@code sidekiq_options\s+.*queue:\s*[:']([^'",\s}]+)}</li>
+ *   <li>{@code PERFORM_INVOCATION_PATTERN}: {@code ([A-Z][a-zA-Z0-9_]*(?:::[A-Z][a-zA-Z0-9_]*)*)\\.perform_(?:async|in|at)\s*\(}</li>
+ * </ul>
+ *
+ * <p><b>Example Usage</b></p>
+ * <pre>{@code
+ * // Worker definition
+ * class EmailWorker
+ *   include Sidekiq::Worker
+ *   sidekiq_options queue: :notifications
+ *
+ *   def perform(user_id)
+ *     # Send email
+ *   end
+ * end
+ *
+ * // Job invocation
+ * EmailWorker.perform_async(123)
+ * EmailWorker.perform_in(1.hour, 123)
+ * }</pre>
+ *
+ * @see MessageFlow
+ * @see AbstractRegexScanner
+ * @since 1.0.0
+ */
+public class SidekiqScanner extends AbstractRegexScanner {
+
+    private static final String SCANNER_ID = "sidekiq-jobs";
+    private static final String SCANNER_DISPLAY_NAME = "Sidekiq Job Scanner";
+    private static final String PATTERN_RUBY_FILES = "**/*.rb";
+    private static final String MESSAGE_TYPE_SIDEKIQ = "sidekiq";
+    private static final String DEFAULT_QUEUE = "default";
+    private static final String RUBY_FILE_EXTENSION = "\\.rb$";
+
+    private static final int MAX_CLASS_SEARCH_LINES = 200;
+
+    /**
+     * Regex to match Sidekiq worker includes.
+     * Matches: include Sidekiq::Worker or include ApplicationWorker
+     */
+    private static final Pattern WORKER_INCLUDE_PATTERN = Pattern.compile(
+        "include\\s+(?:Sidekiq::Worker|ApplicationWorker)"
+    );
+
+    /**
+     * Regex to match module definitions.
+     * Matches: module Notifications
+     * Captures: (1) module name
+     */
+    private static final Pattern MODULE_DEFINITION_PATTERN = Pattern.compile(
+        "^\\s*module\\s+([A-Z][a-zA-Z0-9_]*)"
+    );
+
+    /**
+     * Regex to match class definitions.
+     * Matches: class EmailWorker or class MyModule::EmailWorker
+     * Captures: (1) class name (including namespace)
+     */
+    private static final Pattern CLASS_DEFINITION_PATTERN = Pattern.compile(
+        "^\\s*class\\s+([A-Z][a-zA-Z0-9_]*(?:::[A-Z][a-zA-Z0-9_]*)*)"
+    );
+
+    /**
+     * Regex to extract queue name from sidekiq_options.
+     * Matches: sidekiq_options queue: :notifications or queue: 'emails'
+     * Captures: (1) queue name
+     */
+    private static final Pattern SIDEKIQ_OPTIONS_PATTERN = Pattern.compile(
+        "sidekiq_options\\s+.*?queue:\\s*[:'\"]([^'\"\\s,}]+)"
+    );
+
+    /**
+     * Regex to match job invocations.
+     * Matches: EmailWorker.perform_async(...) or MyModule::EmailWorker.perform_in(...)
+     * Captures: (1) worker class name (including namespace)
+     */
+    private static final Pattern PERFORM_INVOCATION_PATTERN = Pattern.compile(
+        "([A-Z][a-zA-Z0-9_]*(?:::[A-Z][a-zA-Z0-9_]*)*)\\.perform_(?:async|in|at)\\s*\\("
+    );
+
+    @Override
+    public String getId() {
+        return SCANNER_ID;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return SCANNER_DISPLAY_NAME;
+    }
+
+    @Override
+    public Set<String> getSupportedLanguages() {
+        return Set.of(Technologies.RUBY);
+    }
+
+    @Override
+    public Set<String> getSupportedFilePatterns() {
+        return Set.of(PATTERN_RUBY_FILES);
+    }
+
+    @Override
+    public int getPriority() {
+        return 50;
+    }
+
+    @Override
+    public boolean appliesTo(ScanContext context) {
+        return hasAnyFiles(context, PATTERN_RUBY_FILES);
+    }
+
+    @Override
+    public ScanResult scan(ScanContext context) {
+        log.info("Scanning Sidekiq jobs in: {}", context.rootPath());
+
+        List<MessageFlow> messageFlows = new ArrayList<>();
+        List<Path> rubyFiles = context.findFiles(PATTERN_RUBY_FILES).toList();
+
+        if (rubyFiles.isEmpty()) {
+            return emptyResult();
+        }
+
+        // First pass: collect all worker definitions
+        Map<String, WorkerDefinition> workerDefinitions = new HashMap<>();
+        for (Path rubyFile : rubyFiles) {
+            try {
+                collectWorkerDefinitions(rubyFile, workerDefinitions);
+            } catch (Exception e) {
+                log.warn("Failed to parse Ruby file for worker definitions: {} - {}", rubyFile, e.getMessage());
+            }
+        }
+
+        // Second pass: find job invocations and create message flows
+        for (Path rubyFile : rubyFiles) {
+            try {
+                findJobInvocations(rubyFile, workerDefinitions, messageFlows);
+            } catch (Exception e) {
+                log.warn("Failed to parse Ruby file for job invocations: {} - {}", rubyFile, e.getMessage());
+            }
+        }
+
+        log.info("Found {} Sidekiq message flows", messageFlows.size());
+
+        return buildSuccessResult(
+            List.of(),           // No components
+            List.of(),           // No dependencies
+            List.of(),           // No API endpoints
+            messageFlows,        // Message flows
+            List.of(),           // No data entities
+            List.of(),           // No relationships
+            List.of()            // No warnings
+        );
+    }
+
+    /**
+     * Collects all worker definitions from a Ruby file.
+     */
+    private void collectWorkerDefinitions(Path file, Map<String, WorkerDefinition> workerDefinitions) throws IOException {
+        List<String> lines = readFileLines(file);
+        String componentId = extractModuleName(file);
+
+        List<String> moduleStack = new ArrayList<>();
+
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
+
+            // Track module nesting
+            Matcher moduleMatcher = MODULE_DEFINITION_PATTERN.matcher(line);
+            if (moduleMatcher.find()) {
+                moduleStack.add(moduleMatcher.group(1));
+                continue;
+            }
+
+            // Check for class definition
+            Matcher classMatcher = CLASS_DEFINITION_PATTERN.matcher(line);
+            if (classMatcher.find()) {
+                String className = classMatcher.group(1);
+
+                // Build fully qualified class name with module namespace
+                String fullyQualifiedName = className;
+                if (!moduleStack.isEmpty() && !className.contains("::")) {
+                    // Only prepend module if class name doesn't already have namespace
+                    fullyQualifiedName = String.join("::", moduleStack) + "::" + className;
+                }
+
+                // Check if this class includes Sidekiq::Worker or ApplicationWorker
+                boolean isSidekiqWorker = false;
+                String queueName = null;
+
+                // Look ahead for include Sidekiq::Worker and sidekiq_options
+                for (int j = i + 1; j < Math.min(i + MAX_CLASS_SEARCH_LINES, lines.size()); j++) {
+                    String lookAheadLine = lines.get(j);
+
+                    // Stop at next class definition
+                    if (CLASS_DEFINITION_PATTERN.matcher(lookAheadLine).find()) {
+                        break;
+                    }
+
+                    // Check for Sidekiq worker include
+                    if (WORKER_INCLUDE_PATTERN.matcher(lookAheadLine).find()) {
+                        isSidekiqWorker = true;
+                    }
+
+                    // Check for sidekiq_options queue
+                    Matcher optionsMatcher = SIDEKIQ_OPTIONS_PATTERN.matcher(lookAheadLine);
+                    if (optionsMatcher.find()) {
+                        queueName = optionsMatcher.group(1);
+                    }
+
+                    // Stop at 'end' that likely closes the class (simplified check)
+                    if (lookAheadLine.trim().equals("end")) {
+                        break;
+                    }
+                }
+
+                if (isSidekiqWorker) {
+                    WorkerDefinition workerDef = new WorkerDefinition(
+                        fullyQualifiedName,
+                        componentId,
+                        queueName != null ? queueName : DEFAULT_QUEUE
+                    );
+
+                    workerDefinitions.put(fullyQualifiedName, workerDef);
+                    log.debug("Found Sidekiq worker: {} in queue: {}", fullyQualifiedName, workerDef.queueName);
+                }
+            }
+
+            // Handle 'end' statements - pop module stack when we see 'end'
+            // This is simplified - a proper implementation would track nesting depth
+            if (line.trim().equals("end") && !moduleStack.isEmpty()) {
+                moduleStack.remove(moduleStack.size() - 1);
+            }
+        }
+    }
+
+    /**
+     * Finds job invocations and creates message flows.
+     */
+    private void findJobInvocations(
+            Path file,
+            Map<String, WorkerDefinition> workerDefinitions,
+            List<MessageFlow> messageFlows) throws IOException {
+
+        List<String> lines = readFileLines(file);
+        String producerComponentId = extractModuleName(file);
+
+        for (String line : lines) {
+            Matcher invocationMatcher = PERFORM_INVOCATION_PATTERN.matcher(line);
+            while (invocationMatcher.find()) {
+                String workerClassName = invocationMatcher.group(1);
+
+                WorkerDefinition workerDef = workerDefinitions.get(workerClassName);
+                if (workerDef == null) {
+                    // Worker not found - might be external or imported
+                    log.debug("Job invocation found but worker definition not found: {}", workerClassName);
+                    continue;
+                }
+
+                MessageFlow messageFlow = new MessageFlow(
+                    producerComponentId,
+                    workerDef.componentId,
+                    workerDef.queueName,
+                    workerDef.workerClassName,
+                    null,  // No schema for Sidekiq jobs
+                    MESSAGE_TYPE_SIDEKIQ
+                );
+
+                messageFlows.add(messageFlow);
+                log.debug("Found Sidekiq invocation: {} -> {} (queue: {})",
+                    producerComponentId, workerDef.workerClassName, workerDef.queueName);
+            }
+        }
+    }
+
+    /**
+     * Extracts module name from file path.
+     * Converts app/workers/email_worker.rb -> email_worker
+     */
+    private String extractModuleName(Path file) {
+        String fileName = file.getFileName().toString();
+        return fileName.replaceAll(RUBY_FILE_EXTENSION, "");
+    }
+
+    /**
+     * Internal class to hold worker definition information.
+     */
+    private static class WorkerDefinition {
+        final String workerClassName;
+        final String componentId;
+        final String queueName;
+
+        WorkerDefinition(String workerClassName, String componentId, String queueName) {
+            this.workerClassName = workerClassName;
+            this.componentId = componentId;
+            this.queueName = queueName;
+        }
+    }
+}

--- a/doc-architect-core/src/main/resources/META-INF/services/com.docarchitect.core.scanner.Scanner
+++ b/doc-architect-core/src/main/resources/META-INF/services/com.docarchitect.core.scanner.Scanner
@@ -41,6 +41,7 @@ com.docarchitect.core.scanner.impl.go.GoStructScanner
 com.docarchitect.core.scanner.impl.ruby.BundlerDependencyScanner
 com.docarchitect.core.scanner.impl.ruby.RailsApiScanner
 com.docarchitect.core.scanner.impl.ruby.RailsRouteScanner
+com.docarchitect.core.scanner.impl.ruby.SidekiqScanner
 
 # Schema & API Definition Scanners
 com.docarchitect.core.scanner.impl.schema.GraphQLScanner

--- a/doc-architect-core/src/test/java/com/docarchitect/core/scanner/ScannerServiceLoaderTest.java
+++ b/doc-architect-core/src/test/java/com/docarchitect/core/scanner/ScannerServiceLoaderTest.java
@@ -28,13 +28,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   <li>Duplicate scanner IDs</li>
  * </ul>
  *
- * <p>Expected scanner count: 34 scanners
+ * <p>Expected scanner count: 35 scanners
  * <ul>
  *   <li>10 Java/JVM scanners (Maven, Gradle, Spring Components, Spring REST, JAX-RS, JPA, MongoDB, Kafka, RabbitMQ, HTTP Client)</li>
  *   <li>7 Python scanners (Pip/Poetry, Django Apps, FastAPI, Flask, SQLAlchemy, Django ORM, Celery)</li>
  *   <li>5 .NET scanners (NuGet, Solution File, ASP.NET Core, Entity Framework, Kafka)</li>
  *   <li>3 Go scanners (Go Modules, Go HTTP Router, Go Struct/ORM)</li>
- *   <li>3 Ruby scanners (Bundler, Rails API, Rails Route)</li>
+ *   <li>4 Ruby scanners (Bundler, Rails API, Rails Route, Sidekiq)</li>
  *   <li>6 Additional scanners (GraphQL, Avro, Protobuf, SQL, npm, Express)</li>
  * </ul>
  *
@@ -48,7 +48,7 @@ class ScannerServiceLoaderTest {
      * Expected number of scanner implementations.
      * Update this constant when adding new scanners.
      */
-    private static final int EXPECTED_SCANNER_COUNT = 34;
+    private static final int EXPECTED_SCANNER_COUNT = 35;
 
     @Test
     void serviceLoader_discoversAllRegisteredScanners() {
@@ -142,6 +142,7 @@ class ScannerServiceLoaderTest {
                 "bundler-dependencies",
                 "rails-api",
                 "rails-route",
+                "sidekiq-jobs",
                 "graphql-schema",
                 "avro-schema",
                 "protobuf-schema",

--- a/doc-architect-core/src/test/java/com/docarchitect/core/scanner/impl/ruby/SidekiqScannerTest.java
+++ b/doc-architect-core/src/test/java/com/docarchitect/core/scanner/impl/ruby/SidekiqScannerTest.java
@@ -1,0 +1,573 @@
+package com.docarchitect.core.scanner.impl.ruby;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.docarchitect.core.model.MessageFlow;
+import com.docarchitect.core.scanner.ScanResult;
+import com.docarchitect.core.scanner.ScannerTestBase;
+import com.docarchitect.core.util.Technologies;
+
+/**
+ * Unit tests for {@link SidekiqScanner}.
+ */
+class SidekiqScannerTest extends ScannerTestBase {
+
+    private final SidekiqScanner scanner = new SidekiqScanner();
+
+    @Test
+    void getId_returnsCorrectId() {
+        assertThat(scanner.getId()).isEqualTo("sidekiq-jobs");
+    }
+
+    @Test
+    void getDisplayName_returnsCorrectName() {
+        assertThat(scanner.getDisplayName()).isEqualTo("Sidekiq Job Scanner");
+    }
+
+    @Test
+    void getSupportedLanguages_returnsRuby() {
+        assertThat(scanner.getSupportedLanguages()).containsExactly(Technologies.RUBY);
+    }
+
+    @Test
+    void getSupportedFilePatterns_returnsRubyFiles() {
+        assertThat(scanner.getSupportedFilePatterns()).containsExactly("**/*.rb");
+    }
+
+    @Test
+    void getPriority_returns50() {
+        assertThat(scanner.getPriority()).isEqualTo(50);
+    }
+
+    @Test
+    void appliesTo_withRubyFiles_returnsTrue() throws IOException {
+        createFile("app/workers/test_worker.rb", "# test");
+
+        assertThat(scanner.appliesTo(context)).isTrue();
+    }
+
+    @Test
+    void appliesTo_withoutRubyFiles_returnsFalse() {
+        assertThat(scanner.appliesTo(context)).isFalse();
+    }
+
+    @Test
+    void scan_withSidekiqWorker_findsWorker() throws IOException {
+        // Create worker with Sidekiq::Worker
+        String workerContent = """
+            class EmailWorker
+              include Sidekiq::Worker
+              sidekiq_options queue: :notifications
+
+              def perform(user_id)
+                # Send email
+              end
+            end
+            """;
+        createFile("app/workers/email_worker.rb", workerContent);
+
+        // Create service that invokes the worker
+        String serviceContent = """
+            class UserService
+              def register_user(user_id)
+                EmailWorker.perform_async(user_id)
+              end
+            end
+            """;
+        createFile("app/services/user_service.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.publisherComponentId()).isEqualTo("user_service");
+        assertThat(flow.subscriberComponentId()).isEqualTo("email_worker");
+        assertThat(flow.topic()).isEqualTo("notifications");
+        assertThat(flow.messageType()).isEqualTo("EmailWorker");
+        assertThat(flow.broker()).isEqualTo("sidekiq");
+    }
+
+    @Test
+    void scan_withApplicationWorker_findsWorker() throws IOException {
+        // Create worker with ApplicationWorker (Rails pattern)
+        String workerContent = """
+            class NotificationWorker
+              include ApplicationWorker
+              sidekiq_options queue: :mailers
+
+              def perform(notification_id)
+                # Send notification
+              end
+            end
+            """;
+        createFile("app/workers/notification_worker.rb", workerContent);
+
+        String serviceContent = """
+            class NotificationService
+              def send_notification(notification_id)
+                NotificationWorker.perform_async(notification_id)
+              end
+            end
+            """;
+        createFile("app/services/notification_service.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.topic()).isEqualTo("mailers");
+        assertThat(flow.messageType()).isEqualTo("NotificationWorker");
+    }
+
+    @Test
+    void scan_withDefaultQueue_usesDefaultQueue() throws IOException {
+        // Worker without explicit queue specification
+        String workerContent = """
+            class DataProcessingWorker
+              include Sidekiq::Worker
+
+              def perform(data_id)
+                # Process data
+              end
+            end
+            """;
+        createFile("app/workers/data_processing_worker.rb", workerContent);
+
+        String serviceContent = """
+            class DataService
+              def process_data(data_id)
+                DataProcessingWorker.perform_async(data_id)
+              end
+            end
+            """;
+        createFile("app/services/data_service.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.topic()).isEqualTo("default");  // Sidekiq default queue
+    }
+
+    @Test
+    void scan_withPerformIn_findsInvocation() throws IOException {
+        String workerContent = """
+            class ReminderWorker
+              include Sidekiq::Worker
+              sidekiq_options queue: :scheduled
+
+              def perform(user_id)
+                # Send reminder
+              end
+            end
+            """;
+        createFile("app/workers/reminder_worker.rb", workerContent);
+
+        String serviceContent = """
+            class ReminderService
+              def schedule_reminder(user_id)
+                ReminderWorker.perform_in(1.hour, user_id)
+              end
+            end
+            """;
+        createFile("app/services/reminder_service.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.messageType()).isEqualTo("ReminderWorker");
+        assertThat(flow.topic()).isEqualTo("scheduled");
+    }
+
+    @Test
+    void scan_withPerformAt_findsInvocation() throws IOException {
+        String workerContent = """
+            class ScheduledWorker
+              include Sidekiq::Worker
+
+              def perform(task_id)
+                # Execute scheduled task
+              end
+            end
+            """;
+        createFile("app/workers/scheduled_worker.rb", workerContent);
+
+        String serviceContent = """
+            class TaskScheduler
+              def schedule_at(task_id, time)
+                ScheduledWorker.perform_at(time, task_id)
+              end
+            end
+            """;
+        createFile("app/services/task_scheduler.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.messageType()).isEqualTo("ScheduledWorker");
+    }
+
+    @Test
+    void scan_withQueueAsString_extractsQueue() throws IOException {
+        String workerContent = """
+            class EmailWorker
+              include Sidekiq::Worker
+              sidekiq_options queue: 'emails'
+
+              def perform(user_id)
+                # Send email
+              end
+            end
+            """;
+        createFile("app/workers/email_worker.rb", workerContent);
+
+        String serviceContent = """
+            class UserService
+              def send_email(user_id)
+                EmailWorker.perform_async(user_id)
+              end
+            end
+            """;
+        createFile("app/services/user_service.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.topic()).isEqualTo("emails");
+    }
+
+    @Test
+    void scan_withNamespacedWorker_findsWorker() throws IOException {
+        // Worker with namespace
+        String workerContent = """
+            module Notifications
+              class EmailWorker
+                include Sidekiq::Worker
+                sidekiq_options queue: :notifications
+
+                def perform(user_id)
+                  # Send email
+                end
+              end
+            end
+            """;
+        createFile("app/workers/notifications/email_worker.rb", workerContent);
+
+        String serviceContent = """
+            class UserService
+              def register_user(user_id)
+                Notifications::EmailWorker.perform_async(user_id)
+              end
+            end
+            """;
+        createFile("app/services/user_service.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.messageType()).isEqualTo("Notifications::EmailWorker");
+    }
+
+    @Test
+    void scan_withMultipleWorkers_findsAllWorkers() throws IOException {
+        String worker1Content = """
+            class EmailWorker
+              include Sidekiq::Worker
+              sidekiq_options queue: :emails
+
+              def perform(user_id)
+              end
+            end
+            """;
+        createFile("app/workers/email_worker.rb", worker1Content);
+
+        String worker2Content = """
+            class SmsWorker
+              include Sidekiq::Worker
+              sidekiq_options queue: :sms
+
+              def perform(phone_number)
+              end
+            end
+            """;
+        createFile("app/workers/sms_worker.rb", worker2Content);
+
+        String serviceContent = """
+            class NotificationService
+              def notify_user(user_id, phone)
+                EmailWorker.perform_async(user_id)
+                SmsWorker.perform_async(phone)
+              end
+            end
+            """;
+        createFile("app/services/notification_service.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(2);
+
+        List<String> workers = result.messageFlows().stream()
+            .map(MessageFlow::messageType)
+            .toList();
+        assertThat(workers).containsExactlyInAnyOrder("EmailWorker", "SmsWorker");
+
+        List<String> queues = result.messageFlows().stream()
+            .map(MessageFlow::topic)
+            .toList();
+        assertThat(queues).containsExactlyInAnyOrder("emails", "sms");
+    }
+
+    @Test
+    void scan_withWorkerInSameFile_findsFlow() throws IOException {
+        String content = """
+            class ProcessingWorker
+              include Sidekiq::Worker
+
+              def perform(data_id)
+                # Process data
+              end
+            end
+
+            class DataProcessor
+              def process(data_id)
+                ProcessingWorker.perform_async(data_id)
+              end
+            end
+            """;
+        createFile("app/lib/processor.rb", content);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.publisherComponentId()).isEqualTo("processor");
+        assertThat(flow.subscriberComponentId()).isEqualTo("processor");
+    }
+
+    @Test
+    void scan_withMultipleInvocations_findsAllFlows() throws IOException {
+        String workerContent = """
+            class EmailWorker
+              include Sidekiq::Worker
+
+              def perform(user_id)
+              end
+            end
+            """;
+        createFile("app/workers/email_worker.rb", workerContent);
+
+        String service1Content = """
+            class UserRegistration
+              def register(user_id)
+                EmailWorker.perform_async(user_id)
+              end
+            end
+            """;
+        createFile("app/services/user_registration.rb", service1Content);
+
+        String service2Content = """
+            class UserService
+              def notify(user_id)
+                EmailWorker.perform_async(user_id)
+              end
+            end
+            """;
+        createFile("app/services/user_service.rb", service2Content);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(2);
+        assertThat(result.messageFlows())
+            .extracting(MessageFlow::publisherComponentId)
+            .containsExactlyInAnyOrder("user_registration", "user_service");
+    }
+
+    @Test
+    void scan_withNoInvocations_returnsEmpty() throws IOException {
+        String workerContent = """
+            class UnusedWorker
+              include Sidekiq::Worker
+
+              def perform(data)
+              end
+            end
+            """;
+        createFile("app/workers/unused_worker.rb", workerContent);
+
+        ScanResult result = scanner.scan(context);
+
+        // Worker is defined but never invoked
+        assertThat(result.messageFlows()).isEmpty();
+    }
+
+    @Test
+    void scan_withNonWorkerClass_returnsEmpty() throws IOException {
+        String content = """
+            class RegularClass
+              def regular_method
+              end
+            end
+            """;
+        createFile("app/lib/regular_class.rb", content);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).isEmpty();
+    }
+
+    @Test
+    void scan_withEmptyFile_returnsEmpty() throws IOException {
+        createFile("app/workers/empty.rb", "");
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).isEmpty();
+    }
+
+    @Test
+    void scan_withComplexSidekiqOptions_extractsQueue() throws IOException {
+        String workerContent = """
+            class ComplexWorker
+              include Sidekiq::Worker
+              sidekiq_options queue: :high_priority, retry: 5, backtrace: true
+
+              def perform(data)
+              end
+            end
+            """;
+        createFile("app/workers/complex_worker.rb", workerContent);
+
+        String serviceContent = """
+            class Service
+              def process(data)
+                ComplexWorker.perform_async(data)
+              end
+            end
+            """;
+        createFile("app/services/service.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.topic()).isEqualTo("high_priority");
+    }
+
+    @Test
+    void scan_withRealWorldGitLabWorker_findsWorker() throws IOException {
+        // Example based on actual GitLab worker pattern
+        String workerContent = """
+            # frozen_string_literal: true
+
+            class RepositoryImportWorker
+              include ApplicationWorker
+
+              data_consistency :always
+              feature_category :importers
+              sidekiq_options retry: false, dead: false
+
+              def perform(project_id)
+                # Import repository
+              end
+            end
+            """;
+        createFile("app/workers/repository_import_worker.rb", workerContent);
+
+        String controllerContent = """
+            class ProjectsController < ApplicationController
+              def import
+                RepositoryImportWorker.perform_async(project.id)
+              end
+            end
+            """;
+        createFile("app/controllers/projects_controller.rb", controllerContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.messageType()).isEqualTo("RepositoryImportWorker");
+        assertThat(flow.topic()).isEqualTo("default");  // No queue specified
+    }
+
+    @Test
+    void scan_withMultiplePerformMethods_findsAllInvocations() throws IOException {
+        String workerContent = """
+            class FlexibleWorker
+              include Sidekiq::Worker
+              sidekiq_options queue: :flexible
+
+              def perform(data)
+              end
+            end
+            """;
+        createFile("app/workers/flexible_worker.rb", workerContent);
+
+        String serviceContent = """
+            class Scheduler
+              def schedule_tasks
+                FlexibleWorker.perform_async('immediate')
+                FlexibleWorker.perform_in(5.minutes, 'delayed')
+                FlexibleWorker.perform_at(Time.now + 1.hour, 'scheduled')
+              end
+            end
+            """;
+        createFile("app/services/scheduler.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(3);
+        assertThat(result.messageFlows())
+            .extracting(MessageFlow::messageType)
+            .containsOnly("FlexibleWorker");
+        assertThat(result.messageFlows())
+            .extracting(MessageFlow::topic)
+            .containsOnly("flexible");
+    }
+
+    @Test
+    void scan_withCommentsAndWhitespace_handlesCorrectly() throws IOException {
+        String workerContent = """
+            # This is a comment
+            class EmailWorker
+              # Include Sidekiq worker
+              include Sidekiq::Worker
+
+              # Set queue options
+              sidekiq_options queue: :emails
+
+              # Perform email sending
+              def perform(user_id)
+                # Send email logic
+              end
+            end
+            """;
+        createFile("app/workers/email_worker.rb", workerContent);
+
+        String serviceContent = """
+            class UserService
+              def send_welcome_email(user_id)
+                # Send welcome email asynchronously
+                EmailWorker.perform_async(user_id)
+              end
+            end
+            """;
+        createFile("app/services/user_service.rb", serviceContent);
+
+        ScanResult result = scanner.scan(context);
+
+        assertThat(result.messageFlows()).hasSize(1);
+        MessageFlow flow = result.messageFlows().get(0);
+        assertThat(flow.messageType()).isEqualTo("EmailWorker");
+        assertThat(flow.topic()).isEqualTo("emails");
+    }
+}


### PR DESCRIPTION
## Summary
Implements Sidekiq job scanner for detecting Ruby background job message flows in GitLab and other Rails applications.

Closes #164

## Changes

### Sidekiq Scanner Implementation
- Created `SidekiqScanner` extending `AbstractRegexScanner` for Ruby
- Detects `Sidekiq::Worker` and `ApplicationWorker` includes
- Extracts queue names from `sidekiq_options` configuration
- Identifies job invocations via `perform_async`, `perform_in`, `perform_at`
- Supports namespaced workers (e.g., `Notifications::EmailWorker`)
- Module nesting tracking for correct fully qualified class names

### Pattern Detection
✅ Worker definitions: `include Sidekiq::Worker` and `include ApplicationWorker`  
✅ Queue specification: `sidekiq_options queue: :notifications` (symbol or string)  
✅ Job invocations: `EmailWorker.perform_async(args)`  
✅ Delayed jobs: `Worker.perform_in(1.hour, args)` and `Worker.perform_at(time, args)`  
✅ Default queue handling: "default" when no queue specified

### Testing
- Created `SidekiqScannerTest` with 24 comprehensive unit tests
- Tests cover worker detection, queue extraction, invocation patterns
- Namespaced workers, multiple invocation methods, edge cases
- All 24 tests passing successfully
- Validated against GitLab codebase: **found 30+ Sidekiq message flows**

### Integration
- Added to `META-INF/services/com.docarchitect.core.scanner.Scanner`
- Updated `ScannerServiceLoaderTest`: 35 scanners (was 34)
- Updated scanner documentation to include Sidekiq
- Full test suite: **998 tests passing**

## Test Results
- ✅ Unit tests: 24/24 passing
- ✅ Full suite: 998/998 passing  
- ✅ GitLab scan: 30 message flows detected (exceeds 20+ requirement)

## Acceptance Criteria - All Met
- ✅ Detects `Sidekiq::Worker` classes
- ✅ Detects `ApplicationWorker` classes  
- ✅ Extracts queue names from `sidekiq_options`
- ✅ Finds `perform_async`/`perform_in`/`perform_at` invocations
- ✅ Creates `MessageFlow` records with correct queue names
- ✅ GitLab shows 20+ Sidekiq message flows (found 30+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)