### PR TITLE
fix: prevent negative filesSkipped in quality metrics

### DIFF
--- a/doc-architect-core/src/main/java/com/docarchitect/core/util/QualityMetricsCalculator.java
+++ b/doc-architect-core/src/main/java/com/docarchitect/core/util/QualityMetricsCalculator.java
@@ -37,7 +37,8 @@ public final class QualityMetricsCalculator {
         // Calculate file statistics
         int totalFilesInProject = estimateTotalFiles(context);
         int filesAnalyzed = calculateFilesAnalyzed(scanResults);
-        int filesSkipped = totalFilesInProject - filesAnalyzed;
+        // Ensure filesSkipped is non-negative (analyzedfiles can exceed total due to scanner overlap)
+        int filesSkipped = Math.max(0, totalFilesInProject - filesAnalyzed);
 
         // Calculate coverage by component
         Map<String, ArchitectureComponentMetrics> coverageByComponent =


### PR DESCRIPTION
Fixes second bug in QualityMetricsCalculator where filesSkipped could become negative, causing IllegalArgumentException.

## Root Cause

filesSkipped = totalFilesInProject - filesAnalyzed

When filesAnalyzed > totalFilesInProject, result is negative. This happens because:
- estimateTotalFiles() uses glob patterns (unique file count)
- calculateFilesAnalyzed() sums filesScanned from all scanners
- Scanners may count same files multiple times (overlap)

Example:
- Total: 1000 files (unique)
- Maven scanner: 500 files scanned
- Spring scanner: 700 files scanned (overlaps with Maven)
- filesAnalyzed = 1200 → filesSkipped = -200 ❌

## Fix

Use Math.max(0, difference) to ensure non-negative:
```java
int filesSkipped = Math.max(0, totalFilesInProject - filesAnalyzed);
```

## Impact

- Prevents IllegalArgumentException in Apache Camel test
- Allows scans to complete even with scanner overlap
- Quality metrics now generate for all projects

## Testing

- ✅ All 1088 unit tests still pass
- ✅ Build successful
- Ready for integration testing

Related: #188, #189, #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)