### PR TITLE
fix: correct YAML syntax for AUTO mode scanner configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ DocArchitect offers three flexible ways to configure which scanners analyze your
 Let DocArchitect automatically detect and enable all applicable scanners based on your project's structure and technologies. Scanners self-filter based on file presence and applicability.
 
 ```yaml
-scanners: auto
+scanners:
+  mode: auto
 ```
 
 **When to use**: Initial documentation generation, exploring a new codebase, or when you want comprehensive coverage without manual configuration.
@@ -141,7 +142,7 @@ repositories:
 scanners:
   # AUTO mode: Let DocArchitect automatically detect and enable scanners
   # based on your project's technologies
-  auto
+  mode: auto
 
   # OR use explicit mode: Specify which scanners to enable
   # enabled:

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,8 @@ DocArchitect offers three flexible ways to configure which scanners analyze your
 Let DocArchitect automatically detect and enable all applicable scanners based on your project's structure and technologies. Scanners self-filter based on file presence and applicability.
 
 ```yaml
-scanners: auto
+scanners:
+  mode: auto
 ```
 
 **When to use**: Initial documentation generation, exploring a new codebase, or when you want comprehensive coverage without manual configuration.
@@ -151,7 +152,7 @@ repositories:
 scanners:
   # AUTO mode: Let DocArchitect automatically detect and enable scanners
   # based on your project's technologies
-  auto
+  mode: auto
 
   # OR use explicit mode: Specify which scanners to enable
   # enabled:

--- a/examples/test-apache-camel.sh
+++ b/examples/test-apache-camel.sh
@@ -35,7 +35,8 @@ repositories:
   - name: "camel-examples"
     path: "."
 
-scanners: auto
+scanners:
+  mode: auto
 
 generators:
   default: mermaid

--- a/examples/test-dotnet-eshoponcontainers.sh
+++ b/examples/test-dotnet-eshoponcontainers.sh
@@ -32,7 +32,8 @@ repositories:
   - name: "eshoponcontainers"
     path: "."
 
-scanners: auto
+scanners:
+  mode: auto
 
 generators:
   default: mermaid

--- a/examples/test-dotnet-umbraco.sh
+++ b/examples/test-dotnet-umbraco.sh
@@ -32,7 +32,8 @@ repositories:
   - name: "umbraco"
     path: "."
 
-scanners: auto
+scanners:
+  mode: auto
 
 generators:
   default: mermaid


### PR DESCRIPTION
## Summary
Fix critical YAML syntax error in AUTO mode scanner configuration.

## Problem
PR #196 introduced `scanners: auto` which is invalid YAML according to the `ScannerConfig` record structure. Jackson fails to parse this correctly, causing the scanner configuration to be ignored and resulting in "0 scanners executed" warnings.

## Root Cause
The `ScannerConfig` record expects a nested object with a `mode` field:
```java
public record ScannerConfig(
    @JsonProperty("mode") ScannerMode mode,
    @JsonProperty("enabled") List<String> enabled,
    @JsonProperty("groups") List<String> groups,
    @JsonProperty("config") Map<String, Object> config
) { ... }
```

## Solution
Changed from:
```yaml
scanners: auto  # ❌ Invalid - parsed as string, not ScannerConfig object
```

To:
```yaml
scanners:
  mode: auto    # ✅ Correct - maps to ScannerConfig record
```

## Changes
- Fixed YAML syntax in `examples/test-apache-camel.sh`
- Fixed YAML syntax in `examples/test-dotnet-eshoponcontainers.sh`
- Fixed YAML syntax in `examples/test-dotnet-umbraco.sh`
- Updated documentation in `README.md` to show correct syntax
- Updated documentation in `docs/index.md` to show correct syntax

## Testing
With this fix, the 3 test scripts should properly enable AUTO mode and eliminate the "0 scanners executed" warnings.

## Related Issues
Fixes issue introduced in PR #196
Related to #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)