### PR TITLE
fix: correct message flow count extraction in validation test

### DIFF
--- a/examples/test-messaging-validation.sh
+++ b/examples/test-messaging-validation.sh
@@ -196,8 +196,11 @@ fi
 echo "Checking index.md for message flow metrics..."
 cat "$INDEX_FILE" | grep -E "Message Flows|message" || true
 
-# Extract message flow count if available
-FLOW_COUNT=$(grep -E "Message Flows.*\|.*[0-9]+" "$INDEX_FILE" | grep -oE "[0-9]+" | head -1 || echo "0")
+# Extract message flow count from Architecture Statistics section (not coverage table)
+# The statistics section has format: | Message Flows | 8 |
+# The coverage table has format: | Message Flows | 0 | 8 | 100% ✅ |
+# We want the statistics value (8), not the coverage expected baseline (0)
+FLOW_COUNT=$(grep -E "^\| Message Flows \| [0-9]+ \|$" "$INDEX_FILE" | grep -oE "[0-9]+" | head -1 || echo "0")
 
 echo ""
 echo "Message flows detected: $FLOW_COUNT"


### PR DESCRIPTION
## Summary

Fixes false negative in `test-messaging-validation.sh` where the test was FAILING despite scanners working perfectly and detecting all expected message flows.

## Problem

The messaging validation test reported:
```
Message flows detected: 0
✗ FAIL: Found 0 message flows (expected >= 4)
```

But the **actual scanner results** were:
- Kafka scanner: **4 message flows** detected ✅
- RabbitMQ scanner: **4 message flows** detected ✅
- **Total: 8 message flows** (expected >= 4) ✅

**The scanners were working correctly** - only the test validation logic was broken!

## Root Cause

The `index.md` file generated by the markdown generator contains TWO tables with "Message Flows":

**1. Coverage Table** (generated first):
```markdown
| Message Flows | 0 | 8 | 100% ✅ |
                 ↑
              Expected baseline
```

**2. Statistics Table** (generated second):
```markdown
| Message Flows | 8 |
                 ↑
              Actual count
```

The old grep pattern matched **both lines** and extracted **all numbers**:
```bash
grep -E "Message Flows.*\|.*[0-9]+" "$INDEX_FILE" | grep -oE "[0-9]+" | head -1
# Output: 0, 8, 100, 8 (from both tables)
# head -1 takes: 0 (the coverage baseline, not actual count!)
```

## Fix

Changed the grep pattern to match **only the statistics table format**:

```bash
# Before: Matches both tables, extracts wrong number
FLOW_COUNT=$(grep -E "Message Flows.*\|.*[0-9]+" "$INDEX_FILE" | grep -oE "[0-9]+" | head -1 || echo "0")

# After: Matches only statistics table (| Message Flows | 8 |)
FLOW_COUNT=$(grep -E "^\| Message Flows \| [0-9]+ \|$" "$INDEX_FILE" | grep -oE "[0-9]+" | head -1 || echo "0")
```

The new pattern:
- `^` - Start of line
- `\| Message Flows \|` - Exact column format
- `[0-9]+ \|` - Number followed by closing pipe
- `$` - End of line

This matches ONLY the statistics table format, not the coverage table.

## Verification

From the console-out.txt analysis:
- ✅ Kafka scanner detected 4 flows (validation-topic, processed-topic, order-events, payment-events)
- ✅ RabbitMQ scanner detected 4 flows (validation-queue, response-queue, order-queue, payment-queue)
- ✅ Total: 8 flows detected
- ✅ Expected: >= 4 flows
- ✅ **Test should PASS** with this fix

## Impact

- ✅ Removes false negative from test suite
- ✅ Validates that PR #198 scanner fixes are working correctly
- ✅ Test suite should now be 23/23 passing (was 22/23 due to this bug)

## Related PRs

- PR #198: Fixed scanner applicability and configuration (merged)
- This PR: Fixes the test validation that proves #198 worked

## Files Changed

- `examples/test-messaging-validation.sh` - Fixed grep pattern on line 207

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>