### PR TITLE
fix: ensure Docker output directories have write permissions

### DIFF
--- a/examples/test-dotnet-solution.sh
+++ b/examples/test-dotnet-solution.sh
@@ -50,10 +50,12 @@ EOF
 echo ""
 echo "Running DocArchitect on eShopOnWeb..."
 # Create output directory with correct permissions before Docker mount
-mkdir -p "$(pwd)/output/eshopweb"
+OUTPUT_DIR="$(pwd)/output/eshopweb"
+mkdir -p "$OUTPUT_DIR"
+chmod 777 "$OUTPUT_DIR"  # Ensure Docker container can write to it
 docker run --rm \
     -v "$(pwd)/$PROJECT_DIR:/workspace:ro" \
-    -v "$(pwd)/output/eshopweb:/output" \
+    -v "$OUTPUT_DIR:/output" \
     ghcr.io/emilholmegaard/doc-architect:latest \
     scan /workspace --config /workspace/docarchitect.yaml --output /output
 

--- a/examples/test-python-fastapi.sh
+++ b/examples/test-python-fastapi.sh
@@ -50,10 +50,12 @@ EOF
 echo ""
 echo "Running DocArchitect on FastAPI project..."
 # Create output directory with correct permissions before Docker mount
-mkdir -p "$(pwd)/output/fastapi"
+OUTPUT_DIR="$(pwd)/output/fastapi"
+mkdir -p "$OUTPUT_DIR"
+chmod 777 "$OUTPUT_DIR"  # Ensure Docker container can write to it
 docker run --rm \
     -v "$(pwd)/$PROJECT_DIR:/workspace:ro" \
-    -v "$(pwd)/output/fastapi:/output" \
+    -v "$OUTPUT_DIR:/output" \
     ghcr.io/emilholmegaard/doc-architect:latest \
     scan /workspace --config /workspace/docarchitect.yaml --output /output
 

--- a/examples/test-spring-microservices.sh
+++ b/examples/test-spring-microservices.sh
@@ -50,10 +50,12 @@ EOF
 echo ""
 echo "Running DocArchitect on PiggyMetrics..."
 # Create output directory with correct permissions before Docker mount
-mkdir -p "$(pwd)/output/piggymetrics"
+OUTPUT_DIR="$(pwd)/output/piggymetrics"
+mkdir -p "$OUTPUT_DIR"
+chmod 777 "$OUTPUT_DIR"  # Ensure Docker container can write to it
 docker run --rm \
     -v "$(pwd)/$PROJECT_DIR:/workspace:ro" \
-    -v "$(pwd)/output/piggymetrics:/output" \
+    -v "$OUTPUT_DIR:/output" \
     ghcr.io/emilholmegaard/doc-architect:latest \
     scan /workspace --config /workspace/docarchitect.yaml --output /output
 


### PR DESCRIPTION
## Summary
- Fix `AccessDeniedException` in real-world-tests GitHub Actions workflow
- Add `chmod 777` to output directories before Docker mounting in test scripts
- Improve FileSystemRenderer error messages for permission issues

## Problem
The [real-world-tests workflow](https://github.com/emilholmegaard/doc-architect/actions/runs/20706734050/job/59438693698) was failing with:

```
java.nio.file.AccessDeniedException: /output/c4-context.md
```

This occurred because Docker containers run with different UIDs and the mounted output directories didn't have write permissions.

## Changes

### Test Scripts
Updated three test scripts to set proper permissions before Docker mount:
- [examples/test-spring-microservices.sh](examples/test-spring-microservices.sh)
- [examples/test-dotnet-solution.sh](examples/test-dotnet-solution.sh)
- [examples/test-python-fastapi.sh](examples/test-python-fastapi.sh)

Added:
```bash
OUTPUT_DIR="$(pwd)/output/[project]"
mkdir -p "$OUTPUT_DIR"
chmod 777 "$OUTPUT_DIR"  # Ensure Docker container can write to it
```

### FileSystemRenderer
Enhanced [FileSystemRenderer.java](doc-architect-core/src/main/java/com/docarchitect/core/renderer/impl/FileSystemRenderer.java) with:
- Explicit writability checks before file operations
- Better error messages mentioning Docker permission requirements
- Fail-fast behavior with actionable guidance

## Test Plan
- ✅ All unit tests passing (1096 tests)
- ✅ JaCoCo coverage maintained
- ✅ Compilation successful
- ⏳ Will verify in real-world-tests workflow once merged

## Related Issue
Fixes the failure in https://github.com/emilholmegaard/doc-architect/actions/runs/20706734050

🤖 Generated with [Claude Code](https://claude.com/claude-code)