### PR TITLE
fix(ci): use trivy to generate SBOM — syft is not in PATH

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -154,7 +154,7 @@ jobs:
       
       - name: Generate SBOM
         run: |
-          syft ${{ env.DOCKER_IMAGE }}:weekly -o json > sbom.json
+          trivy image --format cyclonedx-json --output sbom.json ${{ env.DOCKER_IMAGE }}:weekly
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Replaces `syft` with `trivy image --format cyclonedx-json` in the Generate SBOM step

## Root cause

Previous attempts (PR #251, #252) failed to land this fix due to a merge conflict that was silently resolved in the wrong direction — the merge of `main` back into the fix branch overwrote the `trivy` change with `syft`, so the squash-merge saw an empty diff.

This is a clean fix from `main` directly.

`anchore/scan-action` uses syft internally but does not add it to `$PATH`, causing `syft: command not found` (exit 127). `trivy` is already in `$PATH` after `aquasecurity/trivy-action` runs earlier in the same job.

## Test plan

- [ ] Weekly build Comprehensive Security Scan / Generate SBOM step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)