### PR TITLE
fix(ci): use spdx-json format for trivy SBOM — cyclonedx-json is invalid

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -154,7 +154,7 @@ jobs:
       
       - name: Generate SBOM
         run: |
-          trivy image --format cyclonedx-json --output sbom.json ${{ env.DOCKER_IMAGE }}:weekly
+          trivy image --format spdx-json --output sbom.json ${{ env.DOCKER_IMAGE }}:weekly
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
trivy v0.69.3 does not support 'cyclonedx-json'; valid formats are: table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln. Use spdx-json for a standard JSON SBOM output.

Tested locally with trivy 0.69.3 — confirmed valid SPDX JSON output.